### PR TITLE
Added a BYO PSP guide

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -20,7 +20,7 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12.10"
+    python: "3.13"
 #  jobs:
 #    post_build:
 #      - mkdir -p $READTHEDOCS_OUTPUT/html/

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -21,7 +21,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.13"
-  jobs:
-    post_build:
-      - mkdir -p $READTHEDOCS_OUTPUT/html/
-      - sphinx-build -n -b text docs $READTHEDOCS_OUTPUT/html/
+#  jobs:
+#    post_build:
+#      - mkdir -p $READTHEDOCS_OUTPUT/html/
+#      - sphinx-build -n -b text docs $READTHEDOCS_OUTPUT/html/

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,12 +9,6 @@ version: 2
 sphinx:
   configuration: source/conf.py
 
-
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.11"
-
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
@@ -22,3 +16,12 @@ formats: all
 python:
   install:
     - requirements: requirements.txt
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.13"
+  jobs:
+    post_build:
+      - mkdir -p $READTHEDOCS_OUTPUT/html/
+      - sphinx-build -n -b text docs $READTHEDOCS_OUTPUT/html/

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -20,7 +20,7 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.12.10"
 #  jobs:
 #    post_build:
 #      - mkdir -p $READTHEDOCS_OUTPUT/html/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinx-tabs
 sphinxcontrib-contentui
 sphinx_rtd_theme
 sphinx-copybutton
-docutils==0.20.1
+#docutils==0.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+sphinxcontrib-mermaid
 sphinx-tabs
 sphinxcontrib-contentui
 sphinx_rtd_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -46,7 +46,8 @@ extensions = [
     'sphinx_tabs.tabs',
     'sphinxcontrib.contentui',
     'sphinx_rtd_theme',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'sphinxcontrib.mermaid'
     ]
 # extensions = ['sphinx_tabs.tabs']
 
@@ -220,6 +221,7 @@ rst_prolog = """
 .. |tokenUrl| replace:: https://infosubscription.eu.auth0.com/oauth/token
 .. |auth0domain| replace:: infosubscription.eu.auth0.com
 .. |ADB2C| replace:: `ADB2C <https://docs.microsoft.com/en-us/azure/active-directory-b2c/overview/>`__
+.. |PayEx| replace:: `Swedbank Pay (formerly PayEx) <https://www.swedbankpay.com/>`__
 .. |Swedbank| replace:: `Swedbank Pay <https://www.swedbankpay.com/>`__
 .. |SwedbankPay| replace:: `Swedbank Pay <https://www.swedbankpay.com/>`__
 .. |eFaktura| replace:: `eFaktura <https://www.efaktura.no/>`__

--- a/source/index.rst
+++ b/source/index.rst
@@ -92,7 +92,6 @@ Please refer to the section on :ref:`Support and Reporting Bugs <reporting-bugs>
     :hidden:
 
     payments/index
-    payments/requests
     billing/standalone
 
 .. toctree::

--- a/source/payments/external-provider-integration.rst
+++ b/source/payments/external-provider-integration.rst
@@ -15,7 +15,7 @@ Third-party systems can:
 
 Integration Steps
 -----------------
-Multiple steps are involved in the integration process, and their are differences and nuances depending on the external payment providers capabilities. 
+Multiple steps are involved in the integration process, and there are differences and nuances depending on the external payment providers capabilities. 
 The following is a high-level overview of the integration steps:
 
 1. Register Payment Agreements

--- a/source/payments/external-provider-integration.rst
+++ b/source/payments/external-provider-integration.rst
@@ -15,7 +15,7 @@ Third-party systems can:
 
 Integration Steps
 -----------------
-Multiple steps are involved in the integration process, and there are differences and nuances depending on the external payment providers capabilities. 
+Multiple steps are involved in the integration process, and there are differences and nuances depending on the external payment provider's capabilities. 
 The following is a high-level overview of the integration steps:
 
 1. Register Payment Agreements
@@ -37,7 +37,7 @@ The following is a high-level overview of the integration steps:
 
 5. Manage Agreement Lifecycle
    - Use the API to update, switch, or terminate payment agreements as needed.
-   - Listen for agreement lifecycle events via webhooks to keep your system in sync. (e.g. , `CreditNoteIssued`, `SubscriptionCancelled`, `PaymentAgreementDeleted`)
+   - Listen for agreement lifecycle events via webhooks to keep your system in sync. (e.g., `CreditNoteIssued`, `SubscriptionCancelled`, `PaymentAgreementDeleted`)
 
 6. Import Agreements (Optional)
    - If agreements are registered outside INFO-Subscription, use the API to import them.

--- a/source/payments/external-provider-integration.rst
+++ b/source/payments/external-provider-integration.rst
@@ -78,5 +78,5 @@ The following is a sequence diagram depicting this example workflow.
 References
 ----------
 - See :ref:`events` for webhook documentation.
-- See :api-ref:`Paymens API <Payment>` for payment details.
+- See :api-ref:`Payments API <Payment>` for payment details.
 - See :ref:`subscribers` for subscriber management.

--- a/source/payments/external-provider-integration.rst
+++ b/source/payments/external-provider-integration.rst
@@ -1,0 +1,82 @@
+.. _external_payment_provider_integration:
+
+Bring Your Own Payment Provider
+===============================
+
+This guide describes how a third-party (API consumer) can integrate an external payment provider with INFO-Subscription using only the public API and webhooks. The integration is based on invoice-related events and reporting payment results via the Payments API.
+
+Overview
+--------
+Third-party systems can:
+
+- Listen for billing/invoice related events via webhooks.
+- Initiate payments with their own provider when invoices are due.
+- Report payment results to INFO-Subscription using the Payments API.
+
+Integration Steps
+-----------------
+Multiple steps are involved in the integration process, and their are differences and nuances depending on the external payment providers capabilities. 
+The following is a high-level overview of the integration steps:
+
+1. Register Payment Agreements
+   - Use the API to create and manage payment agreements for the subscribers.
+   - POST Agreement details to `/paymentagreement`.
+   - Store provider-specific references in your own system.
+
+2. Listen for Invoice Events via Webhooks
+   - Subscribe to invoice-related webhooks (e.g., `InvoiceIssued`).
+   - Implement a webhook receiver to process these events.
+
+3. Handle Invoice Payment Requests
+   - On receiving an invoice event (such as `InvoiceIssued`), fetch paymentdemand, invoice and subscriber details using the API.
+   - Initiate payment with your external provider using the agreement reference.
+
+4. Report Payment Results
+   - After processing the payment, report the result to INFO-Subscription using the Payments API.
+   - POST payment (success/) to `/payment`.
+
+5. Manage Agreement Lifecycle
+   - Use the API to update, switch, or terminate payment agreements as needed.
+   - Listen for agreement lifecycle events via webhooks to keep your system in sync. (e.g. , `CreditNoteIssued`, `SubscriptionCancelled`, `PaymentAgreementDeleted`)
+
+6. Import Agreements (Optional)
+   - If agreements are registered outside INFO-Subscription, use the API to import them.
+
+Example Workflow
+----------------
+1. User subscribes and registers a payment agreement via your UI.
+2. You POST the agreement to INFO-Subscription’s API.
+3. INFO-Subscription triggers a webhook when an invoice is issued.
+4. Your system receives the webhook, processes the payment externally, and reports the result via the Payments API.
+
+The following is a sequence diagram depicting this example workflow.
+
+.. mermaid::
+
+   %%{init: { 'sequence': { 'mirrorActors': false } } }%%
+   sequenceDiagram
+      actor Subscriber
+      participant ThirdPartySystem
+      participant INFO-Subscription
+      participant ExternalPaymentProvider
+
+      Subscriber->>ThirdPartySystem: Register payment agreement
+      
+      ThirdPartySystem->>INFO-Subscription: Create agreement (`POST /paymentagreement`)
+      
+      activate INFO-Subscription
+      Note right of INFO-Subscription: Wait for billing
+      INFO-Subscription-->>ThirdPartySystem: Event: InvoiceIssued
+      deactivate INFO-Subscription
+
+      ThirdPartySystem->>INFO-Subscription: GET /invoice/{id}, GET /subscriber/{id}
+      ThirdPartySystem->>ExternalPaymentProvider: Initiate payment
+      ExternalPaymentProvider-->>ThirdPartySystem: Payment result
+      ThirdPartySystem->>INFO-Subscription: POST /payment
+      INFO-Subscription-->>ThirdPartySystem: Payment status updated
+
+References
+----------
+- See :ref:`events` for webhook documentation.
+- See :api-ref:`Paymens API <Payment>` for payment details.
+- See :ref:`subscribers` for subscriber management.

--- a/source/payments/index.rst
+++ b/source/payments/index.rst
@@ -14,6 +14,8 @@ Different agreement types provides different capabilities and routines.
 All subscribers can have a payment agreement called `None` or `InvoiceOnly`. 
 This basically means there is no way to claim the amount so the system does no attempts at generating a payment.
 
+For details on adding a custom/external payment provider integration refer to :doc:`external-provider-integration`.
+
 Properties of a Payment Agreement
 =================================
 All payment agreements have a few important properties
@@ -121,9 +123,9 @@ There are some variations, so look to the provider descriptions for the details.
 
 Common for all the scenarios is that once an agreement has been imported for the provider, it should be added as a general agreement, and handled the same way as with new orders or during self-service registrations, as :ref:`described above <manage-payment-agreement>`.
 
-*********************
-Provider Integrations
-*********************
+************************
+Payment Providers (PSPs) 
+************************
 
 .. toctree::
     :glob:
@@ -134,3 +136,4 @@ Provider Integrations
     providers/vipps
     providers/swedbank
     providers/betalingsservice
+    external-provider-integration

--- a/source/payments/providers/swedbank.rst
+++ b/source/payments/providers/swedbank.rst
@@ -1,7 +1,7 @@
 .. _provider-swedbank:
 
-Swedbank Pay
-=============
+Swedbank Pay (Card Payments)
+============================
 
 Swedbank Pay is a Payment Service Provider (PSP), formerly PayEx. 
 Swedbank Pay provides a series of different payment services, among these are handling of credit/debit card payments.

--- a/source/payments/providers/vipps.rst
+++ b/source/payments/providers/vipps.rst
@@ -118,7 +118,7 @@ Automatic Accounting/Settlement
 -------------------------------
 It is possible to have |projectName| handle settlement and accounting for an `epayment`. 
 
-All that is required is to fill out the required `Accounting` properties when :api-ref:`creating the epayment <MobilePay/CreatePayment>`.
+All that is required is to fill out the required `Accounting` properties when :api-ref:`creating the epayment <VippsMobilePay/CreatePayment>`.
 
 An example request with accounting data that automagically settles an Invoice may look like:
 

--- a/source/payments/requests.rst
+++ b/source/payments/requests.rst
@@ -1,7 +1,0 @@
-.. _payment-requests:
-
-********************
-Payment Requests
-********************
-
-Here is placeholder text


### PR DESCRIPTION
Added a guide for how to integrate a custom payment provider with INFO-Subscription.

This include support for mermaid diagrams and a few minor adjustsments to existing provider integration documents.

I also removed the placeholder "payment requests" document as it is unlikely to be filled any time soon.