### PR TITLE
Hotfix notes 27 april

### DIFF
--- a/source/changelog/r141.inc
+++ b/source/changelog/r141.inc
@@ -1,3 +1,17 @@
+**********************
+Release April 27th
+**********************
+
+Small hotfix to fix an issue related to session handling when completing orders in checkout.
+
+Checkout
+=========
+
+Fixed
+-----
+
+* Fixed an issue where redirects to/from the Vipps and MobilePay apps would lead to lost sessions on iOS, causing orders to not be completed properly, relying on the fallback check in all cases. This was caused by a change in behaviour of an unsupported feature that checkout unknowingly relied upon.
+
 .. _changelog-r141:
 
 **********************


### PR DESCRIPTION
This pull request introduces a small hotfix to address a session handling issue during checkout. The fix ensures that redirects to and from the Vipps and MobilePay apps on iOS no longer result in lost sessions, which previously caused orders to fail and rely on fallback mechanisms.

Checkout

* Fixed a bug where iOS users completing orders via Vipps or MobilePay experienced lost sessions due to changes in unsupported features, leading to incomplete orders and fallback reliance.